### PR TITLE
fix: ensure max HP scales with level

### DIFF
--- a/src/utils/characterUtils.ts
+++ b/src/utils/characterUtils.ts
@@ -82,11 +82,12 @@ export const calculateMaxHP = (characterClass: string, level: number, constituti
   };
 
   const hitDie = hitDiceByClass[characterClass] || 8;
-  
+
   // На 1 уровне = макс хит дайс + модификатор телосложения
   // На каждом следующем уровне в среднем половина хит дайса + 1 + модификатор телосложения
   const baseHP = hitDie + constitutionModifier;
-  const additionalHP = (level - 1) * (Math.floor(hitDie / 2) + 1 + constitutionModifier);
-  
+  const perLevelGain = Math.max(1, Math.floor(hitDie / 2) + 1 + constitutionModifier);
+  const additionalHP = (level - 1) * perLevelGain;
+
   return Math.max(1, baseHP + additionalHP);
 };


### PR DESCRIPTION
### **User description**
## Summary
- avoid negative HP growth for low Constitution

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689a29f0e8cc832cb919910df788aca5


___

### **PR Type**
Bug fix


___

### **Description**
- Fix HP calculation to prevent negative growth per level

- Ensure minimum 1 HP gain per level for low Constitution characters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HP Calculation"] --> B["Per Level Gain"]
  B --> C["Math.max(1, gain)"]
  C --> D["Positive HP Growth"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>characterUtils.ts</strong><dd><code>Fix HP per-level calculation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/characterUtils.ts

<ul><li>Extract per-level HP gain calculation into separate variable<br> <li> Apply <code>Math.max(1, ...)</code> to ensure minimum 1 HP gain per level<br> <li> Fix potential negative HP growth for low Constitution modifiers</ul>


</details>


  </td>
  <td><a href="https://github.com/cerform/shadow-weave-character-sheet/pull/1/files#diff-fcd090903fb0922d51f8bcafcb5b22d46a57e46f5977402c3c8813cbdd3bdfcd">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

